### PR TITLE
Move /e2e-chrome-devtools-mcp command setup into Claude command file

### DIFF
--- a/.claude/commands/e2e-chrome-devtools-mcp.md
+++ b/.claude/commands/e2e-chrome-devtools-mcp.md
@@ -1,0 +1,1 @@
+docs/e2e-testing/RUNBOOK.md を読み込んでその中身を実行する


### PR DESCRIPTION
## Summary
- add the `.claude/commands/e2e-chrome-devtools-mcp.md` command so Claude loads the runbook directly
- revert the RUNBOOK introduction to remove the embedded slash command instructions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e9a336ed98832c86536bcaf3db4c9a